### PR TITLE
fix(legend): key entries by color encoding so recycled colors don't merge (#788)

### DIFF
--- a/packages/core/src/charts/features/featuresLegend.ts
+++ b/packages/core/src/charts/features/featuresLegend.ts
@@ -20,11 +20,9 @@ import {resolveSpec} from "../pipeline/resolveSpec.js";
 import type {VizContext} from "../pipeline/stages.js";
 import type {VizInstance} from "../viz/vizTypes.js";
 
-const legendAttrs = ["fill", "opacity", "texture"];
-
 interface LegendData {
   legendData: DataPoint[];
-  fill: (d: DataPoint, i: number) => string;
+  legendKey: (d: DataPoint, i: number) => string;
   getAttr: (d: DataPoint, i: number, attr: string) => string;
 }
 
@@ -34,7 +32,7 @@ interface LegendData {
     Returns the `legendData` array plus the `fill`/`getAttr` accessors the
     render step reuses.
 */
-function buildLegendData(viz: VizInstance): LegendData {
+export function buildLegendData(viz: VizInstance): LegendData {
   // Source: `_legendData` from the rollupAndFilter pipeline stage — same
   // arg drawLegend received via `drawLegend.bind(this)(this._legendData)`.
   const data: DataPoint[] = viz._legendData || [];
@@ -50,8 +48,27 @@ function buildLegendData(viz: VizInstance): LegendData {
     return typeof value === "function" ? value.bind(viz)(d, i) : value;
   };
 
-  const fill = (d: DataPoint, i: number): string =>
-    legendAttrs.map(a => getAttr(d, i, a)).join("_");
+  // Legend grouping key. Historically this was the resolved paint string
+  // (fill+opacity+texture): distinct categories that the ordinal color scale
+  // recycled onto the same hex collapsed into one scrambled entry (#788). Key
+  // on the color *encoding* input instead — categories keep their own entry
+  // even when two resolve to the same hex — while opacity/texture still split
+  // entries that differ on those secondary encodings. Falls back to the
+  // resolved fill when there's no color accessor to key on (e.g. `.color(false)`
+  // with a custom `shapeConfig.fill`).
+  const legendKey = (d: DataPoint, i: number): string => {
+    const c =
+      typeof viz.schema.color === "function" ? viz.schema.color(d, i) : undefined;
+    const colorKey =
+      c === undefined || c === null
+        ? getAttr(d, i, "fill")
+        : typeof c === "string"
+          ? c
+          : JSON.stringify(c);
+    return [colorKey, getAttr(d, i, "opacity"), getAttr(d, i, "texture")].join(
+      "_",
+    );
+  };
 
   const rollupData = viz.schema.colorScale
     ? data.filter(
@@ -62,7 +79,7 @@ function buildLegendData(viz: VizInstance): LegendData {
     rollupData,
     (leaves: DataPoint[]) =>
       legendData.push(merge(leaves, viz.schema.aggs) as unknown as DataPoint),
-    fill,
+    legendKey,
   );
 
   legendData.sort(viz.schema.legendSort);
@@ -94,7 +111,7 @@ function buildLegendData(viz: VizInstance): LegendData {
     }
   }
 
-  return {legendData, fill, getAttr};
+  return {legendData, legendKey, getAttr};
 }
 
 /**
@@ -108,7 +125,7 @@ function renderLegendFeature(
   built: LegendData,
   layoutMargin: Required<MarginClaim>,
 ): FeatureLayout {
-  const {legendData, fill, getAttr} = built;
+  const {legendData, legendKey, getAttr} = built;
 
   const hidden = (d: DataPoint, i: number): boolean => {
     let id = viz._id(d, i);
@@ -155,7 +172,7 @@ function renderLegendFeature(
 
   viz._legendClass!
     .renderMode("compute")
-    .id(fill)
+    .id(legendKey)
     .align(wide ? "center" : position)
     .direction(wide ? "row" : "column")
     .duration(viz.schema.duration)

--- a/packages/core/test/charts/legend-color-recycle-test.js
+++ b/packages/core/test/charts/legend-color-recycle-test.js
@@ -1,0 +1,137 @@
+import assert from "assert";
+
+import {buildLegendData} from "../../es/src/charts/features/featuresLegend.js";
+
+/**
+    Regression guard for #788 ("Legend gets scrambled if we run out of colors").
+
+    The legend used to roll its entries up by the *resolved* paint string
+    (fill+opacity+texture). Once a chart had more categories than the ordinal
+    color scale has colors, the scale recycled a hex across two distinct
+    categories, their paint strings collided, and `rollup` merged them into a
+    single scrambled entry (illegible label + hover/hide that hit both).
+
+    The fix keys legend entries on the color *encoding* input (`schema.color`)
+    instead, so recycled hues no longer merge — while opacity/texture still
+    split entries, and an intentional coarse color (many groups sharing one
+    color-key) still collapses to one entry.
+*/
+
+// A 16-slot palette (the default scale length). Groups past slot 16 recycle.
+const PALETTE = Array.from(
+  {length: 16},
+  (_, i) => `#${(i + 1).toString(16).padStart(6, "0")}`,
+);
+
+function fakeViz(overrides) {
+  const base = {
+    _drawDepth: 0,
+    _ids: d => [d.group],
+    schema: {
+      aggs: {},
+      colorScale: false,
+      color: d => d.group,
+      shape: () => "Rect",
+      shapeConfig: {opacity: 1, texture: false},
+      legendSort: (a, b) => String(a.group).localeCompare(String(b.group)),
+    },
+  };
+  return {
+    ...base,
+    ...overrides,
+    schema: {...base.schema, ...(overrides && overrides.schema)},
+  };
+}
+
+it("keeps one legend entry per category when colors are recycled (#788)", () => {
+  const groupCount = 18; // > PALETTE.length, so g16/g17 reuse g0/g1's hex
+  const legendData = Array.from({length: groupCount}, (_, i) => ({
+    id: `g${i}`,
+    group: `g${i}`,
+  }));
+  const viz = fakeViz({
+    _legendData: legendData,
+    schema: {
+      // resolved fill recycles the palette — the exact #788 condition
+      shapeConfig: {
+        fill: d => PALETTE[Number(d.group.slice(1)) % PALETTE.length],
+        opacity: 1,
+        texture: false,
+      },
+    },
+  });
+
+  const {legendData: out, legendKey} = buildLegendData(viz);
+
+  assert.strictEqual(out.length, groupCount, "one legend entry per category");
+
+  // The colliding pairs (g0/g16 and g1/g17 share a hex) must stay separate.
+  const groups = out.map(d => d.group);
+  for (const g of ["g0", "g16", "g1", "g17"]) {
+    assert.ok(groups.includes(g), `${g} kept its own entry`);
+    assert.strictEqual(
+      typeof out.find(d => d.group === g).group,
+      "string",
+      `${g} was not merged into a multi-value entry`,
+    );
+  }
+
+  // Every entry resolves to a unique legend key.
+  const keys = new Set(out.map((d, i) => legendKey(d, i)));
+  assert.strictEqual(keys.size, groupCount, "legend keys are unique per entry");
+});
+
+it("collapses groups that intentionally share a color key into one entry", () => {
+  // Coarse coloring: color by continent while drawing at the country level.
+  const countries = [
+    {id: "US", continent: "NA"},
+    {id: "CA", continent: "NA"},
+    {id: "FR", continent: "EU"},
+    {id: "DE", continent: "EU"},
+    {id: "BR", continent: "SA"},
+  ];
+  const viz = fakeViz({
+    _legendData: countries,
+    _drawDepth: 1,
+    _ids: d => [d.continent, d.id],
+    schema: {
+      color: d => d.continent,
+      shapeConfig: {
+        fill: d => ({NA: "#111111", EU: "#222222", SA: "#333333"})[d.continent],
+        opacity: 1,
+        texture: false,
+      },
+      legendSort: (a, b) =>
+        String(a.continent).localeCompare(String(b.continent)),
+    },
+  });
+
+  const {legendData: out} = buildLegendData(viz);
+
+  assert.strictEqual(out.length, 3, "one entry per shared color key (continent)");
+  const continents = out.map(d => d.continent).sort();
+  assert.deepStrictEqual(continents, ["EU", "NA", "SA"], "grouped by continent");
+});
+
+it("still splits entries that differ only by opacity", () => {
+  // Force a single color key so only opacity can distinguish entries.
+  const rows = [
+    {id: "a", group: "g", level: 1},
+    {id: "b", group: "g", level: 0.5},
+  ];
+  const viz = fakeViz({
+    _legendData: rows,
+    schema: {
+      color: () => "shared",
+      shapeConfig: {
+        fill: () => "#123456",
+        opacity: d => d.level,
+        texture: false,
+      },
+    },
+  });
+
+  const {legendData: out} = buildLegendData(viz);
+
+  assert.strictEqual(out.length, 2, "opacity remains a secondary splitter");
+});


### PR DESCRIPTION
## Summary

Fixes #788 — the legend scrambled when a chart had more categories than the color scale has colors.

**Root cause.** `buildLegendData` rolled legend entries up by the *resolved paint string* (`fill + opacity + texture`). Once categories outnumbered the ordinal scale's colors, the scale recycled a hex across two distinct categories, their paint strings collided, and `rollup` merged them into one entry. That single entry got a **merged, often-illegible label**, and because hover/hide keys off `viz._id` on the merged datum, it **highlighted/hid multiple categories at once**.

**Fix.** Key legend entries on the color *encoding input* (`schema.color`) rather than its *resolved hex output*, keeping opacity/texture as secondary splitters. Falls back to the resolved fill when there's no color accessor to key on (e.g. `.color(false)` with a custom `shapeConfig.fill`).

This is a strict generalization of the old behavior:

| scenario | before | after |
|---|---|---|
| < 16 series | 1 entry per series | **unchanged** |
| coarse color (`groupBy=[continent, country]`) | 1 entry per continent | **unchanged** |
| > 16 series (recycled hues) | tail merged into scrambled entries | **1 entry per series, colors repeat as distinct blocks** |

It also does what a literal "color + label" key can't: it preserves intentional color-sharing (one swatch per continent) instead of exploding it into one swatch per country.

## Verification

- **New unit test** (`legend-color-recycle-test.js`): 18 recycled-color groups → 18 distinct entries; coarse coloring still collapses to one entry per color key; opacity still splits.
- `tsc` clean, eslint clean, **235/235 core tests pass** (including the full-render visual snapshots for every chart type — no regression to normal cases).
- **End-to-end in Chromium**, 20-series BarChart: 20 legend entries, 20 distinct labels, 0 entries linking to multiple ids, 16 colors across 20 entries (e.g. *Group A* and *Group Q* share a hue but are now separate blocks).

## Notes

- The palette half of the issue thread (a lighter second ring of 8 colors) already shipped in v4 (`packages/color/src/defaults.ts`). That raised the recycling threshold; this change makes crossing it non-destructive.
- **CHANGELOG intentionally not touched** — this repo compiles the changelog at release time (see the dedicated `v4.3 CHANGELOG` / `compiles v4.3.0` commits, and #804 which deferred it). Happy to add an entry if you'd prefer it in-PR.
- Minor: `buildLegendData` is now exported from `featuresLegend.ts` so the pure grouping logic can be unit-tested directly (matching the existing `applyInteractionOpacity` / `configureOrdinalColor` pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
